### PR TITLE
Raise exception when current_policy is not defined

### DIFF
--- a/lib/access-granted/controller_methods.rb
+++ b/lib/access-granted/controller_methods.rb
@@ -1,7 +1,7 @@
 module AccessGranted
   module ControllerMethods
     def current_policy
-      @current_policy ||= ::Policy.new(current_user)
+      raise NotImplementedError, "You must implement #current_policy in ActionController."
     end
 
     def self.included(base)

--- a/spec/controller_methods_spec.rb
+++ b/spec/controller_methods_spec.rb
@@ -1,31 +1,8 @@
 require "spec_helper"
 
 describe AccessGranted::ControllerMethods do
-  before(:each) do
-    @current_user = double("User")
-    @controller_class = Class.new
-    @controller = @controller_class.new
-    @controller_class.stub(:helper_method).with(:can?, :cannot?, :current_ability)
-    @controller_class.send(:include, AccessGranted::ControllerMethods)
-    @controller.stub(:current_user).and_return(@current_user)
-  end
-
-  it "should have current_policy method returning Policy instance" do
-    @controller.current_policy.should be_kind_of(AccessGranted::Policy)
-  end
-
-  it "provides can? and cannot? method delegated to current_policy" do
-    @controller.can?(:read, String).should be_false
-    @controller.cannot?(:read, String).should be_true
-  end
-
-  describe "#authorize!" do
-    it "raises exception when authorization fails" do
-      expect { @controller.authorize!(:read, String) }.to raise_error(AccessGranted::AccessDenied)
-    end
-
-    it "returns subject if authorization succeeds" do
-      klass = Class.new do
+  before(:all) do
+    @policy = Class.new do
         include AccessGranted::Policy
 
         def configure(user)
@@ -34,9 +11,44 @@ describe AccessGranted::ControllerMethods do
           end
         end
       end
-      policy = klass.new(@current_user)
-      @controller.stub(:current_policy).and_return(policy)
-      @controller.authorize!(:read, String).should == String
+    @controller_class = Class.new
+  end
+
+  before(:each) do
+    @controller_class.stub(:helper_method).with(:can?, :cannot?, :current_ability)
+    @controller_class.send(:include, AccessGranted::ControllerMethods)
+    @controller = @controller_class.new
+    @controller.stub(:current_user).and_return(double('User'))
+  end
+
+  context "when current_policy is not defined" do
+    it "raises exception" do
+      expect { @controller.can?(:read, String).should be_true }.to raise_error(NotImplementedError)
+    end
+  end
+
+  context "when current_policy is defined" do
+    before(:each) do
+      @controller.stub(:current_policy).and_return(@policy.new(@current_user))
+    end
+
+    it "should have current_policy method returning Policy instance" do
+      @controller.current_policy.should be_kind_of(AccessGranted::Policy)
+    end
+
+    it "provides can? and cannot? method delegated to current_policy" do
+      @controller.cannot?(:read, String).should be_false
+      @controller.can?(:read, String).should be_true
+    end
+
+    describe "#authorize!" do
+      it "raises exception when authorization fails" do
+        expect { @controller.authorize!(:update, String) }.to raise_error(AccessGranted::AccessDenied)
+      end
+
+      it "returns subject if authorization succeeds" do
+        @controller.authorize!(:read, String).should == String
+      end
     end
   end
 end


### PR DESCRIPTION
Controller#current_policy was depending on either defining
Policy class with top level namespace or overriding the method.
If none of it has been done the stacktrace was very confusing,
ie:

```
     NameError:
       uninitialized constant Policy
bundler/gems/access-granted-9a2655e7f6f9/lib/access-granted/controller_methods.rb:4:in
`current_policy'
bundler/gems/access-granted-9a2655e7f6f9/lib/access-granted/controller_methods.rb:12:in
`can?'
ruby/gems/2.0.0/gems/actionpack-3.2.14/lib/abstract_controller/helpers.rb:53:in
`can?'
```

Now the error is:

```
     NotImplementedError:
       You must implement #current_policy in ActionController.
```
