### PR TITLE
check for superclass to match permissions, too

### DIFF
--- a/lib/access-granted/permission.rb
+++ b/lib/access-granted/permission.rb
@@ -15,7 +15,7 @@ module AccessGranted
     end
 
     def matches_subject?(subject)
-      @subject == subject || subject.class == @subject
+      subject == @subject || subject.class <= @subject
     end
 
     def matches_conditions?(subject)

--- a/spec/permission_spec.rb
+++ b/spec/permission_spec.rb
@@ -52,5 +52,20 @@ describe AccessGranted::Permission do
       perm = subject.new(true, :read, String)
       expect(perm.matches_subject? "test").to be_true
     end
+
+    it "matches if superclass is equal to subject" do
+      perm = subject.new(true, :read, Object)
+      expect(perm.matches_subject? "test").to be_true
+    end
+
+    it "matches if any ancestor is equal to subject" do
+      perm = subject.new(true, :read, BasicObject)
+      expect(perm.matches_subject? "test").to be_true
+    end
+
+    it "does not match if any descendant is equal to subject" do
+      perm = subject.new(true, :read, String)
+      expect(perm.matches_subject? Object.new).to be_false
+    end
   end
 end


### PR DESCRIPTION
I think this is what users expect - at least I did and wondered what
was wrong.

```
class A
end

class B < A
end

can :read, A

can? :read, B # => true, without this: false
```
