### PR TITLE
Refactor Policy#Role

### DIFF
--- a/lib/access-granted/role.rb
+++ b/lib/access-granted/role.rb
@@ -67,6 +67,10 @@ module AccessGranted
       end
     end
 
+    def to_conditions
+      @conditions
+    end
+
     private
 
     def prepare_actions(action)

--- a/spec/policy_spec.rb
+++ b/spec/policy_spec.rb
@@ -110,13 +110,9 @@ describe AccessGranted::Policy do
 
   describe "#role" do
     it "allows passing role class" do
-      klass_role = Class.new AccessGranted::Role do
-        def configure(user)
-          can :read, String
-        end
-      end
-      @policy.role(:member, klass_role)
-      @policy.roles.first.class.should == klass_role
+      role = AccessGranted::Role.new(:role, 1, foo: "bar")
+      @policy.role(:member, role)
+      @policy.roles.first.conditions.should == role.to_conditions
     end
 
     it "allows defining a default role" do


### PR DESCRIPTION
Was looking at this method last night and it seemed the only thing that really mattered to the client user was the conditions. By using `#to_conditions`, if it's available, it makes this more extensible and and less tied to a specific type/subclass.

The big question though is whether we really care about `@roles` elements keeping their class. I don't see anything in the library that says so, but I may be missing something.
