### PR TITLE
Do not run block if given a class instead of an instance

### DIFF
--- a/lib/access-granted/permission.rb
+++ b/lib/access-granted/permission.rb
@@ -20,7 +20,7 @@ module AccessGranted
     end
 
     def matches_conditions?(subject)
-      if @block
+      if @block && !subject.respond_to?(:new)
         @block.call(subject, @user)
       else
         matches_hash_conditions?(subject)

--- a/lib/access-granted/permission.rb
+++ b/lib/access-granted/permission.rb
@@ -20,7 +20,7 @@ module AccessGranted
     end
 
     def matches_conditions?(subject)
-      if @block && !subject.respond_to?(:new)
+      if @block && !subject.is_a?(Class)
         @block.call(subject, @user)
       else
         matches_hash_conditions?(subject)

--- a/spec/permission_spec.rb
+++ b/spec/permission_spec.rb
@@ -14,6 +14,12 @@ describe AccessGranted::Permission do
       perm = subject.new(true, :read, sub.class, nil, {}, proc {|el| el.published? })
       expect(perm.matches_conditions?(sub)).to eq(true)
     end
+
+    it "does not match proc conditions when given a class instead of an instance" do
+      sub = double("Element", published?: true)
+      perm = subject.new(true, :read, sub.class, nil, {}, proc {|el| el.published? })
+      expect(perm.matches_conditions?(sub.class)).to eq(true)
+    end
   end
 
   describe "#matches_hash_conditions?" do


### PR DESCRIPTION
I ran into an issue where I defined a permission like so:

```ruby
can :manage, Course do |course, user|
  user.school_ids.include? course.school_id
end
```

I wanted to be able to check if the user can manage any course in general like so:

```ruby
can? :manage, Course
```

And then when the user would drill down further I could determine if he could manage the specific courses like so:

```ruby
can? :manage, course
```

However, when I did this I ran into an error since it will try to run the block I gave in the permission definition, even when I give it a class, not an instance of that class. That sparks an `undefined method 'school_id'` error.

This PR only runs the block if you have given it something that is an instance (i.e. does not respond to `#new`).