### PR TITLE
move rails initialization into a railtie

### DIFF
--- a/lib/access-granted.rb
+++ b/lib/access-granted.rb
@@ -3,19 +3,9 @@ require "access-granted/policy"
 require "access-granted/permission"
 require "access-granted/role"
 require "access-granted/rails/controller_methods"
+require "access-granted/railtie" if defined?(Rails)
 
 module AccessGranted
 
 end
 
-if defined? ActionController::Base
-  ActionController::Base.class_eval do
-    include AccessGranted::Rails::ControllerMethods
-  end
-end
-
-if defined? ActionController::API
-  ActionController::API.class_eval do
-    include AccessGranted::Rails::ControllerMethods
-  end
-end

--- a/lib/access-granted/railtie.rb
+++ b/lib/access-granted/railtie.rb
@@ -1,0 +1,19 @@
+require 'rails/railtie'
+
+module AccessGranted
+  class Railtie < ::Rails::Railtie
+    initializer :access_granted do
+      if defined? ActionController::Base
+        ActionController::Base.class_eval do
+          include AccessGranted::Rails::ControllerMethods
+        end
+      end
+
+      if defined? ActionController::API
+        ActionController::API.class_eval do
+          include AccessGranted::Rails::ControllerMethods
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
While trying to integrate AccessGranted into a project, I encountered problems it introduced to the load order of some classes, with confusing breakage happening far down the line as a result.

In particular, some rails modules were patching their own logic into ActionController::API, and doing so in a `Railtie` initializer (I first encountered this with [jbuilder](https://github.com/rails/jbuilder/blob/master/lib/jbuilder/railtie.rb#L6-L15)) . Once I included AccessGranted in my project, I found that the relevant classes were being loaded before this logic; ultimately, my controller lacked the ActionView::Rendering module.

This PR fixes this issue by migrating that logic into the canonical Railtie format as well for access granted. This has enabled me to load up Jbuilder's initializer first.