### PR TITLE
Allow an AccessDenied error to carry context about the rejection

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,6 +210,26 @@ class ApplicationController < ActionController::Base
 end
 ```
 
+You can also extract the action and subject which raised the error,
+if you want to handle authorization errors differently for some cases:
+```ruby
+  rescue_from "AccessGranted::AccessDenied" do |exception|
+    status = case exception.action
+      when :read # invocation like `authorize! :read, @something`
+        403
+      else
+        404
+      end
+
+    body = case exception.subject
+      when Post # invocation like `authorize! @some_action, Post`
+        "failed to access a post"
+      else
+        "failed to access something else"
+      end
+  end
+```
+
 #### Checking permissions in controllers
 
 To check if the user has a permission to perform an action, use the `can?` and `cannot?` methods.

--- a/lib/access-granted/exceptions.rb
+++ b/lib/access-granted/exceptions.rb
@@ -3,5 +3,11 @@ module AccessGranted
 
   class DuplicatePermission < Error; end;
   class DuplicateRole < Error; end;
-  class AccessDenied < Error; end;
+  class AccessDenied < Error
+    attr_reader :action, :subject
+    def initialize(action = nil, subject = nil)
+      @action = action
+      @subject = subject
+    end
+  end
 end

--- a/lib/access-granted/policy.rb
+++ b/lib/access-granted/policy.rb
@@ -58,7 +58,7 @@ module AccessGranted
 
     def authorize!(action, subject)
       if cannot?(action, subject)
-        raise AccessDenied
+        raise AccessDenied.new(action, subject)
       end
       subject
     end

--- a/spec/controller_methods_spec.rb
+++ b/spec/controller_methods_spec.rb
@@ -21,7 +21,11 @@ describe AccessGranted::Rails::ControllerMethods do
 
   describe "#authorize!" do
     it "raises exception when authorization fails" do
-      expect { @controller.authorize!(:read, String) }.to raise_error(AccessGranted::AccessDenied)
+      expect { @controller.authorize!(:read, String) }.to raise_error do |err|
+        expect(err).to be_a(AccessGranted::AccessDenied)
+        expect(err.action).to eq(:read)
+        expect(err.subject).to eq(String)
+      end
     end
 
     it "returns subject if authorization succeeds" do

--- a/spec/policy_spec.rb
+++ b/spec/policy_spec.rb
@@ -136,7 +136,11 @@ describe AccessGranted::Policy do
       end
 
       it "raises AccessDenied if action is not allowed" do
-        expect { klass.new(@member).authorize!(:create, Integer) }.to raise_error AccessGranted::AccessDenied
+        expect { klass.new(@member).authorize!(:create, Integer) }.to raise_error do |err|
+          expect(err).to be_a(AccessGranted::AccessDenied)
+          expect(err.action).to eq(:create)
+          expect(err.subject).to eq(Integer)
+        end
       end
 
       it "returns the subject if allowed" do


### PR DESCRIPTION
As recommended in your Readme, I have a catch-all for AccessDenied errors that come up from an `authorize!` method.

However, this has made all my permissions errors to result in the same error. This is a problem for my API design, because I need to be able to distinguish in a single controller method whether the rejection was "you are not allowed to view this resource" vs "you are not allowed to know whether this resource exists".

There are workarounds to arrange this probably, but they involve diverging from AccessGranted and therefore permissions/access control becomes fragmented.

This PR addresses this by permitting the catch-all to know what action and subject were requested when the error was thrown. In my case, across all subjects I use consistent action names (`:find` rejections always throw 404, `:show` always throw 403); this suggests there is room for further work as well in the realm of "inheritance" of actions (i.e., any validation of `:show` must first pass a check on `:find`), but this is enough to be getting on with.