### PR TITLE
Allow using :manage in array.

### DIFF
--- a/lib/access-granted/role.rb
+++ b/lib/access-granted/role.rb
@@ -69,11 +69,8 @@ module AccessGranted
     end
 
     def prepare_actions(action)
-      if action == :manage
-        actions = [:read, :create, :update, :destroy]
-      else
-        actions = Array(*[action])
-      end
+      actions = Array(*[action])
+      actions.map { |a| a == :manage ? [:create, :read, :update, :destroy ] : [a] }.flatten
     end
   end
 end

--- a/lib/access-granted/role.rb
+++ b/lib/access-granted/role.rb
@@ -70,7 +70,7 @@ module AccessGranted
 
     def prepare_actions(action)
       actions = Array(*[action])
-      actions.map { |a| a == :manage ? [:create, :read, :update, :destroy ] : [a] }.flatten
+      actions.flat_map { |a| a == :manage ? [:create, :read, :update, :destroy ] : [a] }
     end
   end
 end


### PR DESCRIPTION
Right now we _mostly_ use access-granted with `:create` `:read` `:update` and `:destroy` permissions. But sometimes we need a specific added permission (let's say `:create_children`) where it's doesn't really work to say that a person has permissions on the child-record itself.

Right now the following:

```
...
can [:manage, :create_children], ParentModel
...
```

Results in literally adding the `[:manage, :create_children]` permissions, rather than the expected `[:create, :read, :update, :destroy, :create_children]` permissions.

This PR fixes that by always turning the permissions into an array. Then it expands `:manage` to the correct set of permissions.