### PR TITLE
Allow passing custom exception message for authorize!

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,6 +232,21 @@ if you want to handle authorization errors differently for some cases:
   end
 ```
 
+You can also have a custom exception message while authorizing a request.
+This message will be associated with the exception object thrown.
+
+```ruby
+class PostsController
+  def show
+    @post = Post.find(params[:id])
+    authorize! :read, @post, 'You do not have access to this post'
+    render json: { post: @post }
+  rescue AccessGranted::AccessDenied => e
+    render json: { error: e.message }, status: :forbidden
+  end
+end
+```
+
 #### Checking permissions in controllers
 
 To check if the user has a permission to perform an action, use the `can?` and `cannot?` methods.

--- a/lib/access-granted/exceptions.rb
+++ b/lib/access-granted/exceptions.rb
@@ -4,10 +4,11 @@ module AccessGranted
   class DuplicatePermission < Error; end;
   class DuplicateRole < Error; end;
   class AccessDenied < Error
-    attr_reader :action, :subject
-    def initialize(action = nil, subject = nil)
+    attr_reader :action, :subject, :message
+    def initialize(action = nil, subject = nil, message = nil)
       @action = action
       @subject = subject
+      @message = message
     end
   end
 end

--- a/lib/access-granted/policy.rb
+++ b/lib/access-granted/policy.rb
@@ -56,9 +56,9 @@ module AccessGranted
       !can?(*args)
     end
 
-    def authorize!(action, subject)
+    def authorize!(action, subject, message = 'Access Denied')
       if cannot?(action, subject)
-        raise AccessDenied.new(action, subject)
+        raise AccessDenied.new(action, subject, message)
       end
       subject
     end

--- a/spec/policy_spec.rb
+++ b/spec/policy_spec.rb
@@ -143,6 +143,16 @@ describe AccessGranted::Policy do
         end
       end
 
+      it "raises AccessDenied with supplied message if action is not allowed" do
+        message = 'You are not allowed to create Integer'
+        expect { klass.new(@member).authorize!(:create, Integer, message) }.to raise_error do |err|
+          expect(err).to be_a(AccessGranted::AccessDenied)
+          expect(err.action).to eq(:create)
+          expect(err.subject).to eq(Integer)
+          expect(err.message).to eq(message)
+        end
+      end
+
       it "returns the subject if allowed" do
         expect(klass.new(@member).authorize!(:create, String)).to equal String
       end


### PR DESCRIPTION
Sometimes, there is a need for specifying a message along with the authorization of an action. This message is useful as it provides some feedback to the consumer of the action. In some cases, it also acts as a documentation which makes it clear as to why this authorization was introduced.

### Usage

The message passed along with `authorize!` will be accessible on the exception object thrown if the authorization fails.

```ruby
class PostsController
  def show
    @post = Post.find(params[:id])
    authorize! :read, @post, 'You do not have access to this post'
    render json: { post: @post }
  rescue AccessGranted::AccessDenied => e
    render json: { error: e.message }, status: :forbidden
  end
end
```

This PR allows `authorize!` method to optionally take a third argument specifying the custom exception message