### PR TITLE
Updated Railtie to be Zeitwerk compatible when Rails version >= 6

### DIFF
--- a/lib/access-granted/railtie.rb
+++ b/lib/access-granted/railtie.rb
@@ -3,15 +3,25 @@ require 'rails/railtie'
 module AccessGranted
   class Railtie < ::Rails::Railtie
     initializer :access_granted do
-      if defined? ActionController::Base
-        ActionController::Base.class_eval do
-          include AccessGranted::Rails::ControllerMethods
+      if ::Rails::VERSION::MAJOR >= 6
+        ActiveSupport.on_load(:action_controller_base) do |base|
+          base.include AccessGranted::Rails::ControllerMethods
         end
-      end
 
-      if defined? ActionController::API
-        ActionController::API.class_eval do
-          include AccessGranted::Rails::ControllerMethods
+        ActiveSupport.on_load(:action_controller_api) do |base|
+          base.include AccessGranted::Rails::ControllerMethods
+        end
+      else
+        if defined? ActionController::Base
+          ActionController::Base.class_eval do
+            include AccessGranted::Rails::ControllerMethods
+          end
+        end
+
+        if defined? ActionController::API
+          ActionController::API.class_eval do
+            include AccessGranted::Rails::ControllerMethods
+          end
         end
       end
     end


### PR DESCRIPTION
This fixes Zeitwerk detecting constants loaded during initialization.  