### PR TITLE
Allow subclasses to match on superclass subject

### DIFF
--- a/lib/access-granted/permission.rb
+++ b/lib/access-granted/permission.rb
@@ -17,7 +17,9 @@ module AccessGranted
     end
 
     def matches_subject?(subject)
-      subject == @subject || subject.class <= @subject
+      subject == @subject ||
+      (subject.is_a?(Class) && @subject.is_a?(Class) && subject <= @subject) ||
+      subject.class <= @subject
     end
 
     def matches_conditions?(subject)

--- a/spec/permission_spec.rb
+++ b/spec/permission_spec.rb
@@ -49,6 +49,11 @@ describe AccessGranted::Permission do
       expect(perm.matches_subject? String).to eq(true)
     end
 
+    it "matches if superclass of class object is equal to subject" do
+      perm = subject.new(true, :read, Exception)
+      expect(perm.matches_subject? StandardError).to eq(true)
+    end
+
     it "matches if class is equal to subject" do
       perm = subject.new(true, :read, String)
       expect(perm.matches_subject? "test").to eq(true)


### PR DESCRIPTION
if Bicycle < Vehicle, and you have a policy `can :read, Vehicle`, then already `can?(:read, Vehicle.new)` and `can?(:read, Bicycle.new)` are both true.

`can?(:read, Vehicle)` is also true.

I believe `can?(:read, Bicycle)` should also be true, it should respect the subclass. Bicycle is a kind of Vehicle, so if they have been granted permission to read all Vehicles, that applies to all Bicycles too.

Closes #55, see more there.
