### PR TITLE
Update README example to ~> 1.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,14 +8,14 @@ AccessGranted is a multi-role and whitelist based authorization gem for Rails. A
 Add the gem to your gemfile:
 
 ```ruby
-gem 'access-granted', '~> 1.1.0'
+gem 'access-granted', '~> 1.3'
 ```
 Run the bundle command to install it. Then run the generator:
 
     rails generate access_granted:policy
 
 Add the `policies` (and `roles` if you're using it to split up your roles into files) directories to your autoload paths in `application.rb`:
-    
+
 ```ruby
 config.autoload_paths += %W(#{config.root}/app/policies #{config.root}/app/roles)
 ```


### PR DESCRIPTION
Before it said `~> 1.1.0` -- which means 1.1.x.  In a test app I was using to explore, I had just copied and pasted this line, meaning I was accidentally stuck on five-year-old 1.1.2! Was getting very confused debugging something that would have been different in 1.3.

In addition to updating to the more recent 1.3 example in the README, the more important thing is only using two digits, `"~> 1.3"`, which will mean 1.x greater than 1.3.0, and will allow updating ot any future 1.4, 1.5 etc!
